### PR TITLE
Allow For Two Ooyala Players with the Same Content

### DIFF
--- a/demo/dom-two-players-with-same-content.html
+++ b/demo/dom-two-players-with-same-content.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>jquery.ooyala - Basic Usage (HTML)</title>
+    <link href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
+    <style type="text/css">
+      #element {
+        max-width: 100%;
+        width: 600px;
+        height: 400px;
+        margin: 0 auto;
+        padding-bottom: 1em;
+      }
+    </style>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>
+    <script src="../src/jquery.ooyala.js"></script>
+  </head>
+  <body>
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col-md-6">
+          <h2>Output</h2>
+          <div id="element"
+               class="oo-player"
+               data-player-id="e18ab1da1813483499554ea2d8e67fbd"
+               data-content-id="M0dTZ0bTqdn5iPEJDDcK87Gq5tfBL8wO"
+               ></div>
+        </div>
+        <div class="col-md-6">
+          <div id="element"
+               class="oo-player"
+               data-player-id="e18ab1da1813483499554ea2d8e67fbd"
+               data-content-id="M0dTZ0bTqdn5iPEJDDcK87Gq5tfBL8wO"
+               ></div>
+        </div>
+        <div class="col-md-6">
+          <h2>Markup</h2>
+          <pre><code>
+          &lt;div id="element"
+               class="oo-player"
+               data-player-id="e18ab1da1813483499554ea2d8e67fbd"
+               data-content-id="M0dTZ0bTqdn5iPEJDDcK87Gq5tfBL8wO"
+               &gt;&lt;/div&gt;
+          &lt;div id="element"
+               class="oo-player"
+               data-player-id="e18ab1da1813483499554ea2d8e67fbd"
+               data-content-id="M0dTZ0bTqdn5iPEJDDcK87Gq5tfBL8wO"
+               &gt;&lt;/div&gt;
+          </code></pre>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/jquery.ooyala.js
+++ b/src/jquery.ooyala.js
@@ -256,9 +256,9 @@
   function initDOM() {
     var playerPlacement = this.settings.playerPlacement,
         // This is the DOM element that we'll reference in OO.Player.create(), so we
-        // give it a unique id.
+        // give it a truly unique identifier within the DOM.
         $videoContainer = $(
-          "<div id='video_" + this.settings.contentId + "' class='oo-player-video-container'></div>"
+          "<div id='video_" + this.settings.contentId + Date.now() + "' class='oo-player-video-container'></div>"
         );
 
     // There seems to be a bug in istanbul where it can't handle multiple

--- a/test/jquery.ooyala.spec.js
+++ b/test/jquery.ooyala.spec.js
@@ -17,6 +17,13 @@ describe( "jquery.ooyala", function() {
       return this.$el.ooyala.apply(this.$el, args);
     };
 
+    this.initWorld = function() {
+      var ooyala;
+      this.$el.ooyala( this.options );
+      ooyala = this.$el.data( "ooyala" );
+      this.fauxO( ooyala._ooNamespace );
+    };
+
     this.let_( "$oo", this.initPlugin.bind(this) );
 
     spyOn( $, "ajax" ).and.callFake(function() {
@@ -24,12 +31,9 @@ describe( "jquery.ooyala", function() {
       return this.deferred.promise();
     }.bind(this) );
 
-    this.initWorld = function() {
-      var ooyala;
-      this.$el.ooyala( this.options );
-      ooyala = this.$el.data( "ooyala" );
-      this.fauxO( ooyala._ooNamespace );
-    };
+    spyOn(Date, "now").and.callFake(function() {
+      return 666;
+    });
   });
 
   describe( "initialization", function() {
@@ -111,8 +115,8 @@ describe( "jquery.ooyala", function() {
           expect( this.$oo.children().last() ).toHaveClass( "oo-player-video-container" );
         });
 
-        it( "assigns an id of 'video_<contentId>' to the element", function() {
-          expect( this.$oo.find( ".oo-player-video-container" ) ).toHaveAttr( "id", "video_" + this.options.contentId );
+        it( "assigns an id of 'video_<contentId><Date.now()>' to the element", function() {
+          expect( this.$oo.find( ".oo-player-video-container" ) ).toHaveAttr( "id", "video_" + this.options.contentId + "666");
         });
 
         describe( "when options.playerPlacement = 'append'", function() {


### PR DESCRIPTION
Currently we create our unique identifier for the player's DOM element using *just* the player's content identifier. That decision causes a multitude of problems when there are two Ooyala players with the **same content & content identifier** on any given page.

This PR solves said issue by improving the way in which we create our unique identifier for the player's DOM element.

I have also added a new demo page which shows off the new feature.

*(This may be considered an enhancement instead of a bug if having two same-content Ooyala players was never originally considered a use case or part of the scope of this library -- i just put both labels on it for safety's sake)*